### PR TITLE
Issue #8: Remove agent-run and browse from publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ else
 	@xdg-open http://127.0.0.1:$(FLEDGE_WEB_UI_PORT)/
 endif
 
-publish: publish-service publish-service-policy publish-deployment-policy agent-run browse
+publish: publish-service publish-service-policy publish-deployment-policy
 
 publish-service:
 	@echo "=================="


### PR DESCRIPTION
This PR removes the agent-run and browse targets from the publish target in the Makefile. This change aligns with the pattern of keeping node registration separate from service publishing.\n\nFixes #8